### PR TITLE
Test `Workflow` marshalling

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
 # Security Policy
 
-All security issues in `go-gha-models` publicly should be reported publicly as bugs. Private reports
-will be made public by the maintainers after 7 days with best-effort attribution.
+All security issues in `go-gha-models` should be reported publicly as bugs. Private reports will be
+made public by the maintainers after 7 days with best-effort attribution.

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -433,14 +433,7 @@ func checkRuns(t *testing.T, got, want *Runs) {
 
 	/* using: composite */
 
-	if got, want := got.Steps, want.Steps; len(got) != len(want) {
-		t.Errorf("Unexpected number of runs steps (got %d, want %d)", len(got), len(want))
-	} else {
-		for i, got := range got {
-			want := want[i]
-			checkStep(t, &got, &want)
-		}
-	}
+	checkSteps(t, got.Steps, want.Steps)
 
 	/* using: docker */
 

--- a/step.go
+++ b/step.go
@@ -13,12 +13,12 @@ import (
 
 // Step is a model of a workflow/manifest job step.
 type Step struct {
+	Name  string            `yaml:"name,omitempty"`
+	Uses  Uses              `yaml:"uses,omitempty"`
+	Shell string            `yaml:"shell,omitempty"`
+	Run   string            `yaml:"run,omitempty"`
 	With  map[string]string `yaml:"with,omitempty"`
 	Env   map[string]string `yaml:"env,omitempty"`
-	Name  string            `yaml:"name,omitempty"`
-	Run   string            `yaml:"run,omitempty"`
-	Shell string            `yaml:"shell,omitempty"`
-	Uses  Uses              `yaml:"uses,omitempty"`
 }
 
 // Uses is a model of a step `uses:` value.

--- a/workflow.go
+++ b/workflow.go
@@ -15,7 +15,7 @@ type Workflow struct {
 
 // Job is a model of a workflow job.
 type Job struct {
-	Name  string `yaml:"name"`
+	Name  string `yaml:"name,omitempty"`
 	Steps []Step `yaml:"steps"`
 }
 


### PR DESCRIPTION
Relates to #3

Update the `workflow_test.go` suite to include testing of marshalling the `Workflow` model. Based on this, marshalling by omitting fields when they're empty and re-ordering struct fields to obtain more intuitive ordering of fields in the resulting YAML.