### PR TITLE
Fix bugs based on `zed`'s workflows

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -26,7 +26,7 @@ type Job struct {
 	ContinueOnError bool               `yaml:"continue-on-error,omitempty"`
 	TimeoutMinutes  int                `yaml:"timeout-minutes,omitempty"`
 	If              string             `yaml:"if,omitempty"`
-	Needs           []string           `yaml:"needs,omitempty"`
+	Needs           Needs              `yaml:"needs,omitempty"`
 	Concurrency     Concurrency        `yaml:"concurrency,omitempty"`
 	Defaults        Defaults           `yaml:"defaults,omitempty"`
 	Strategy        Strategy           `yaml:"strategy,omitempty"`
@@ -103,6 +103,26 @@ func (e Environment) MarshalYAML() (any, error) {
 	}
 
 	return n, nil
+}
+
+type Needs []string
+
+func (l *Needs) UnmarshalYAML(n *yaml.Node) error {
+	switch n.Kind {
+	case yaml.ScalarNode:
+		*l = []string{n.Value}
+	case yaml.SequenceNode:
+		var list []string
+		if err := n.Decode(&list); err != nil {
+			return err
+		}
+
+		*l = list
+	default:
+		return fmt.Errorf("invalid job.needs %v", n.Kind)
+	}
+
+	return nil
 }
 
 // Permissions is a model of a GitHub Actions `permissions:` object.

--- a/workflow.go
+++ b/workflow.go
@@ -51,6 +51,38 @@ type Concurrency struct {
 	Group            string `yaml:"group,omitempty"`
 }
 
+func (c *Concurrency) UnmarshalYAML(n *yaml.Node) error {
+	switch n.Kind {
+	case yaml.ScalarNode:
+		c.Group = n.Value
+	case yaml.MappingNode:
+		var concurrency map[string]any
+		_ = n.Decode(&concurrency)
+
+		if v, ok := concurrency["cancel-in-progress"]; ok {
+			v, ok := v.(bool)
+			if !ok {
+				return fmt.Errorf("invalid concurrency.cancel-in-progress %v", n.Kind)
+			}
+
+			c.CancelInProgress = v
+		}
+
+		if v, ok := concurrency["group"]; ok {
+			v, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("invalid concurrency.group %v", n.Kind)
+			}
+
+			c.Group = v
+		}
+	default:
+		return fmt.Errorf("invalid concurrency %v", n.Kind)
+	}
+
+	return nil
+}
+
 // Defaults is a model of a GitHub Actions `defaults:` object.
 type Defaults struct {
 	Run DefaultsRun `yaml:"run,omitempty"`

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -702,6 +702,24 @@ jobs:
 		})
 	}
 
+	edgeCases := map[string]TestCase{
+		"non-array job.needs": {
+			yaml: `
+jobs:
+  example:
+    needs: foobar
+`,
+		},
+	}
+
+	for name, tt := range edgeCases {
+		t.Run(name, func(t *testing.T) {
+			if err := yaml.Unmarshal([]byte(tt.yaml), &tt.model); err != nil {
+				t.Fatalf("Want no error, got %#v", err)
+			}
+		})
+	}
+
 	errCases := map[string]TestCase{
 		"yaml: invalid 'name' value": {
 			yaml: `
@@ -829,7 +847,8 @@ jobs:
 			yaml: `
 jobs:
   example:
-    needs: foobar
+    needs:
+      foo: bar
 `,
 		},
 		"yaml: invalid job 'concurrency' value": {


### PR DESCRIPTION
Using this library to parse the workflows of the [`zed-industries/zed`](https://github.com/zed-industries/zed) repo I found some patterns that are not supported:

- Accept `job.needs` values that are not an array.
- TBD