### PR TITLE
Drop the marshalling dream

### DIFF
--- a/manifest_test.go
+++ b/manifest_test.go
@@ -4,9 +4,7 @@ package gha
 
 import (
 	"fmt"
-	"strings"
 	"testing"
-	"testing/quick"
 
 	"gopkg.in/yaml.v3"
 )
@@ -250,18 +248,7 @@ runs:
 	}
 
 	for name, tt := range okCases {
-		t.Run("Marshal: "+name, func(t *testing.T) {
-			got, err := yaml.Marshal(tt.model)
-			if err != nil {
-				t.Fatalf("Want no error, got %#v", err)
-			}
-
-			if got, want := string(got), strings.TrimSpace(tt.yaml)+"\n"; got != want {
-				t.Errorf("Unexpected result\n=== got ===\n%s\n=== want ===\n%s", got, want)
-			}
-		})
-
-		t.Run("Unmarshal: "+name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			got, err := ParseManifest([]byte(tt.yaml))
 			if err != nil {
 				t.Fatalf("Want no error, got %#v", err)
@@ -273,179 +260,179 @@ runs:
 	}
 
 	errCases := map[string]TestCase{
-		"yaml: invalid 'name' value": {
+		"invalid 'name' value": {
 			yaml: `
 name: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'author' value": {
+		"invalid 'author' value": {
 			yaml: `
 author: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'description' value": {
+		"invalid 'description' value": {
 			yaml: `
 description: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'branding' value": {
+		"invalid 'branding' value": {
 			yaml: `
 branding: 3.14
 `,
 		},
-		"yaml: invalid 'color' value for branding": {
+		"invalid 'color' value for branding": {
 			yaml: `
 branding:
   color: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'icon' value for branding": {
+		"invalid 'icon' value for branding": {
 			yaml: `
 branding:
   icon: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'inputs' value": {
+		"invalid 'inputs' value": {
 			yaml: `
 inputs: 3.14
 `,
 		},
-		"yaml: invalid 'default' value for input": {
+		"invalid 'default' value for input": {
 			yaml: `
 inputs:
   foo:
     default: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'deprecationMessage' value for input": {
+		"invalid 'deprecationMessage' value for input": {
 			yaml: `
 inputs:
   foo:
     deprecationMessage: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'description' value for input": {
+		"invalid 'description' value for input": {
 			yaml: `
 inputs:
   foo:
     description: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'required' value for input": {
+		"invalid 'required' value for input": {
 			yaml: `
 inputs:
   foo:
     required: bar
 `,
 		},
-		"yaml: invalid 'outputs' value": {
+		"invalid 'outputs' value": {
 			yaml: `
 outputs: 3.14
 `,
 		},
-		"yaml: invalid 'description' value for output": {
+		"invalid 'description' value for output": {
 			yaml: `
 outputs:
   foo:
     description: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'value' value for output": {
+		"invalid 'value' value for output": {
 			yaml: `
 outputs:
   foo:
     value: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'runs' value": {
+		"invalid 'runs' value": {
 			yaml: `
 runs: 3.14
 `,
 		},
-		"yaml: invalid 'using' value in runs": {
+		"invalid 'using' value in runs": {
 			yaml: `
 runs:
   using: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'steps' value in runs": {
+		"invalid 'steps' value in runs": {
 			yaml: `
 runs:
   using: composite
   steps: 3.14
 `,
 		},
-		"yaml: invalid 'image' value in runs": {
+		"invalid 'image' value in runs": {
 			yaml: `
 runs:
   using: docker
   image: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'args' value in runs": {
+		"invalid 'args' value in runs": {
 			yaml: `
 runs:
   using: docker
   args: foobar
 `,
 		},
-		"yaml: invalid 'env' value in runs": {
+		"invalid 'env' value in runs": {
 			yaml: `
 runs:
   using: docker
   env: foobar
 `,
 		},
-		"yaml: invalid 'pre-entrypoint' value in runs": {
+		"invalid 'pre-entrypoint' value in runs": {
 			yaml: `
 runs:
   using: docker
   pre-entrypoint: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'entrypoint' value in runs": {
+		"invalid 'entrypoint' value in runs": {
 			yaml: `
 runs:
   using: docker
   entrypoint: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'post-entrypoint' value in runs": {
+		"invalid 'post-entrypoint' value in runs": {
 			yaml: `
 runs:
   using: docker
   post-entrypoint: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'pre' value in runs": {
+		"invalid 'pre' value in runs": {
 			yaml: `
 runs:
   using: node
   pre: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'pre-if' value in runs": {
+		"invalid 'pre-if' value in runs": {
 			yaml: `
 runs:
   using: node
   pre-if: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'main' value in runs": {
+		"invalid 'main' value in runs": {
 			yaml: `
 runs:
   using: node
   main: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'post' value in runs": {
+		"invalid 'post' value in runs": {
 			yaml: `
 runs:
   using: node
   post: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'post-if' value in runs": {
+		"invalid 'post-if' value in runs": {
 			yaml: `
 runs:
   using: node
@@ -456,37 +443,10 @@ runs:
 
 	for name, tt := range errCases {
 		t.Run(name, func(t *testing.T) {
-			var err error
-			switch {
-			case strings.HasPrefix(name, "model:"):
-				_, err = yaml.Marshal(tt.model)
-			case strings.HasPrefix(name, "yaml:"):
-				err = yaml.Unmarshal([]byte(tt.yaml), &tt.model)
-			default:
-				t.Fatalf("Incorrect test name %q", name)
-			}
-
-			if err == nil {
+			if err := yaml.Unmarshal([]byte(tt.yaml), &tt.model); err == nil {
 				t.Error("Want an error, got none")
 			}
 		})
-	}
-
-	roundtrip := func(m Manifest) bool {
-		b, err := yaml.Marshal(m)
-		if err != nil {
-			return true
-		}
-
-		if err := yaml.Unmarshal(b, &m); err != nil {
-			return false
-		}
-
-		return true
-	}
-
-	if err := quick.Check(roundtrip, nil); err != nil {
-		t.Error(err)
 	}
 }
 

--- a/step.go
+++ b/step.go
@@ -3,10 +3,8 @@
 package gha
 
 import (
-	"errors"
 	"fmt"
 	"strings"
-	"unicode"
 
 	"gopkg.in/yaml.v3"
 )
@@ -62,33 +60,4 @@ func (u *Uses) UnmarshalYAML(n *yaml.Node) error {
 	u.Annotation = strings.TrimLeft(n.LineComment, "# ")
 
 	return nil
-}
-
-func (u Uses) MarshalYAML() (any, error) {
-	if u.Name == "" && u.Ref == "" {
-		return "", nil
-	}
-
-	if u.Name == "" && u.Ref != "" {
-		return nil, errors.New("missing 'name' value")
-	}
-
-	n := &yaml.Node{
-		Kind:  yaml.ScalarNode,
-		Tag:   "!!str",
-		Value: u.Name,
-		LineComment: strings.Map(func(r rune) rune {
-			if !unicode.IsPrint(r) {
-				return -1
-			}
-
-			return r
-		}, u.Annotation),
-	}
-
-	if u.Ref != "" {
-		n.Value = n.Value + "@" + u.Ref
-	}
-
-	return n, nil
 }

--- a/step_test.go
+++ b/step_test.go
@@ -3,9 +3,7 @@
 package gha
 
 import (
-	"strings"
 	"testing"
-	"testing/quick"
 
 	"gopkg.in/yaml.v3"
 )
@@ -132,18 +130,7 @@ run: echo 'foobaz'
 	}
 
 	for name, tt := range okCases {
-		t.Run("Marshal: "+name, func(t *testing.T) {
-			got, err := yaml.Marshal(tt.model)
-			if err != nil {
-				t.Fatalf("Want no error, got %#v", err)
-			}
-
-			if got, want := string(got), strings.TrimSpace(tt.yaml)+"\n"; got != want {
-				t.Errorf("Unexpected result\n=== got ===\n%s\n=== want ===\n%s", got, want)
-			}
-		})
-
-		t.Run("Unmarshal: "+name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			var got Step
 			if err := yaml.Unmarshal([]byte(tt.yaml), &got); err != nil {
 				t.Fatalf("Want no error, got %#v", err)
@@ -155,58 +142,58 @@ run: echo 'foobaz'
 	}
 
 	errCases := map[string]TestCase{
-		"yaml: invalid 'name' value": {
+		"invalid 'name' value": {
 			yaml: `
 name:
   foo: bar
 `,
 		},
-		"yaml: invalid 'uses' value": {
+		"invalid 'uses' value": {
 			yaml: `
 uses: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'id' value": {
+		"invalid 'id' value": {
 			yaml: `
 id:
   foo: bar
 `,
 		},
-		"yaml: invalid 'if' value": {
+		"invalid 'if' value": {
 			yaml: `
 if:
   foo: bar
 `,
 		},
-		"yaml: invalid 'continue-on-error' value": {
+		"invalid 'continue-on-error' value": {
 			yaml: `continue-on-error: foobar`,
 		},
-		"yaml: invalid 'timeout-minutes' value": {
+		"invalid 'timeout-minutes' value": {
 			yaml: `timeout-minutes: foobar`,
 		},
-		"yaml: invalid 'working-directory' value": {
+		"invalid 'working-directory' value": {
 			yaml: `
 working-directory:
   foo: bar
 `,
 		},
-		"yaml: invalid 'shell' value": {
+		"invalid 'shell' value": {
 			yaml: `
 shell:
   foo: bar
 `,
 		},
-		"yaml: invalid 'run' value": {
+		"invalid 'run' value": {
 			yaml: `
 run: ['foo', 'bar']
 `,
 		},
-		"yaml: invalid 'with' value": {
+		"invalid 'with' value": {
 			yaml: `
 with: not a map
 `,
 		},
-		"yaml: invalid 'env' value": {
+		"invalid 'env' value": {
 			yaml: `
 env: not a map
 `,
@@ -215,37 +202,10 @@ env: not a map
 
 	for name, tt := range errCases {
 		t.Run(name, func(t *testing.T) {
-			var err error
-			switch {
-			case strings.HasPrefix(name, "model:"):
-				_, err = yaml.Marshal(tt.model)
-			case strings.HasPrefix(name, "yaml:"):
-				err = yaml.Unmarshal([]byte(tt.yaml), &tt.model)
-			default:
-				t.Fatalf("Incorrect test name %q", name)
-			}
-
-			if err == nil {
+			if err := yaml.Unmarshal([]byte(tt.yaml), &tt.model); err == nil {
 				t.Error("Want an error, got none")
 			}
 		})
-	}
-
-	roundtrip := func(s Step) bool {
-		b, err := yaml.Marshal(s)
-		if err != nil {
-			return true
-		}
-
-		if err = yaml.Unmarshal(b, &s); err != nil {
-			return false
-		}
-
-		return true
-	}
-
-	if err := quick.Check(roundtrip, nil); err != nil {
-		t.Error(err)
 	}
 }
 
@@ -326,18 +286,7 @@ func TestUses(t *testing.T) {
 	}
 
 	for name, tt := range okCases {
-		t.Run("Marshal: "+name, func(t *testing.T) {
-			got, err := yaml.Marshal(tt.model)
-			if err != nil {
-				t.Fatalf("Want no error, got %#v", err)
-			}
-
-			if got, want := string(got), tt.yaml+"\n"; got != want {
-				t.Errorf("Unexpected result (got %q, want %q)", got, want)
-			}
-		})
-
-		t.Run("Unmarshal: "+name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			var got Uses
 			if err := yaml.Unmarshal([]byte(tt.yaml), &got); err != nil {
 				t.Fatalf("Want no error, got %#v", err)
@@ -349,53 +298,20 @@ func TestUses(t *testing.T) {
 	}
 
 	errCases := map[string]TestCase{
-		"model: missing name": {
-			model: Uses{
-				Ref: "bar",
-			},
-		},
-		"yaml: missing name": {
+		"missing name": {
 			yaml: `@bar`,
 		},
-		"yaml: empty ref": {
+		"empty ref": {
 			yaml: `foo@`,
 		},
 	}
 
 	for name, tt := range errCases {
 		t.Run(name, func(t *testing.T) {
-			var err error
-			switch {
-			case strings.HasPrefix(name, "model:"):
-				_, err = yaml.Marshal(tt.model)
-			case strings.HasPrefix(name, "yaml:"):
-				err = yaml.Unmarshal([]byte(tt.yaml), &tt.model)
-			default:
-				t.Fatalf("Incorrect test name %q", name)
-			}
-
-			if err == nil {
+			if err := yaml.Unmarshal([]byte(tt.yaml), &tt.model); err == nil {
 				t.Error("Want an error, got none")
 			}
 		})
-	}
-
-	roundtrip := func(u Uses) bool {
-		b, err := yaml.Marshal(u)
-		if err != nil {
-			return true
-		}
-
-		var got Uses
-		if err = yaml.Unmarshal(b, &got); err != nil {
-			return false
-		}
-
-		return true
-	}
-
-	if err := quick.Check(roundtrip, nil); err != nil {
-		t.Error(err)
 	}
 }
 

--- a/workflow.go
+++ b/workflow.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"maps"
 	"sort"
-	"strconv"
 
 	"gopkg.in/yaml.v3"
 )
@@ -88,33 +87,6 @@ func (c *Concurrency) UnmarshalYAML(n *yaml.Node) error {
 	return nil
 }
 
-func (c Concurrency) MarshalYAML() (any, error) {
-	var v any
-	switch c.CancelInProgress {
-	case "true", "false":
-		v = struct {
-			CancelInProgress bool   `yaml:"cancel-in-progress"`
-			Group            string `yaml:"group,omitempty"`
-		}{
-			CancelInProgress: c.CancelInProgress == "true",
-			Group:            c.Group,
-		}
-	default:
-		v = struct {
-			CancelInProgress string `yaml:"cancel-in-progress,omitempty"`
-			Group            string `yaml:"group,omitempty"`
-		}{
-			CancelInProgress: c.CancelInProgress,
-			Group:            c.Group,
-		}
-	}
-
-	n := yaml.Node{}
-	_ = n.Encode(v)
-
-	return n, nil
-}
-
 // Defaults is a model of a GitHub Actions `defaults:` object.
 type Defaults struct {
 	Run DefaultsRun `yaml:"run,omitempty"`
@@ -151,22 +123,6 @@ func (e *Environment) UnmarshalYAML(n *yaml.Node) error {
 	}
 
 	return nil
-}
-
-func (e Environment) MarshalYAML() (any, error) {
-	n := yaml.Node{}
-	if e.Url == "" {
-		n.Kind = yaml.ScalarNode
-		n.Tag = "!!str"
-		n.Value = e.Name
-	} else {
-		env := make(map[string]string, 2)
-		env["name"] = e.Name
-		env["url"] = e.Url
-		_ = n.Encode(env)
-	}
-
-	return n, nil
 }
 
 type Needs []string
@@ -300,71 +256,6 @@ func (p *Permissions) UnmarshalYAML(n *yaml.Node) error {
 	return nil
 }
 
-func (p Permissions) MarshalYAML() (any, error) {
-	all := func(s string) bool {
-		return p.Actions == s && p.Attestations == s && p.Checks == s && p.Contents == s && p.Deployments == s && p.Discussions == s && p.IdToken == s && p.Issues == s && p.Models == s && p.Packages == s && p.Pages == s && p.PullRequests == s && p.SecurityEvents == s && p.Statuses == s
-	}
-
-	n := yaml.Node{}
-	switch {
-	case all("read"):
-		n.Kind = yaml.ScalarNode
-		n.Tag = "!!str"
-		n.Value = "read-all"
-	case all("write"):
-		n.Kind = yaml.ScalarNode
-		n.Tag = "!!str"
-		n.Value = "write-all"
-	default:
-		perms := make(map[string]string, 14)
-		if v := p.Actions; v != "none" {
-			perms["actions"] = v
-		}
-		if v := p.Attestations; v != "none" {
-			perms["attestations"] = v
-		}
-		if v := p.Checks; v != "none" {
-			perms["checks"] = v
-		}
-		if v := p.Contents; v != "none" {
-			perms["contents"] = v
-		}
-		if v := p.Deployments; v != "none" {
-			perms["deployments"] = v
-		}
-		if v := p.Discussions; v != "none" {
-			perms["discussions"] = v
-		}
-		if v := p.IdToken; v != "none" {
-			perms["id-token"] = v
-		}
-		if v := p.Issues; v != "none" {
-			perms["issues"] = v
-		}
-		if v := p.Models; v != "none" {
-			perms["models"] = v
-		}
-		if v := p.Packages; v != "none" {
-			perms["packages"] = v
-		}
-		if v := p.Pages; v != "none" {
-			perms["pages"] = v
-		}
-		if v := p.PullRequests; v != "none" {
-			perms["pull-requests"] = v
-		}
-		if v := p.SecurityEvents; v != "none" {
-			perms["security-events"] = v
-		}
-		if v := p.Statuses; v != "none" {
-			perms["statuses"] = v
-		}
-		_ = n.Encode(perms)
-	}
-
-	return n, nil
-}
-
 // Service is a model of a GitHub Actions `services:` object.
 type Service struct {
 	Image       string             `yaml:"image"`
@@ -376,22 +267,6 @@ type Service struct {
 }
 
 type Ports []string
-
-func (p Ports) MarshalYAML() (any, error) {
-	v := make([]any, len(p))
-	for i, p := range p {
-		if n, err := strconv.Atoi(p); err == nil {
-			v[i] = n
-		} else {
-			v[i] = p
-		}
-	}
-
-	n := yaml.Node{}
-	_ = n.Encode(v)
-
-	return n, nil
-}
 
 // ServiceCredentials is a model of a GitHub Actions `services.credentials:` object.
 type ServiceCredentials struct {

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -6,9 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
-	"strings"
 	"testing"
-	"testing/quick"
 
 	"gopkg.in/yaml.v3"
 )
@@ -838,22 +836,7 @@ jobs:
 	}
 
 	for name, tt := range okCases {
-		t.Run("Marshal: "+name, func(t *testing.T) {
-			if strings.HasPrefix(name, "Job matrix,") {
-				t.SkipNow()
-			}
-
-			got, err := yaml.Marshal(tt.model)
-			if err != nil {
-				t.Fatalf("Want no error, got %#v", err)
-			}
-
-			if got, want := string(got), strings.TrimSpace(tt.yaml)+"\n"; got != want {
-				t.Errorf("Unexpected result\n=== got ===\n%s\n=== want ===\n%s", got, want)
-			}
-		})
-
-		t.Run("Unmarshal: "+name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			got, err := ParseWorkflow([]byte(tt.yaml))
 			if err != nil {
 				t.Fatalf("Want no error, got %#v", err)
@@ -904,91 +887,91 @@ jobs:
 	}
 
 	errCases := map[string]TestCase{
-		"yaml: invalid 'name' value": {
+		"invalid 'name' value": {
 			yaml: `
 name:
 - foo
 - bar
 `,
 		},
-		"yaml: invalid 'run-name' value": {
+		"invalid 'run-name' value": {
 			yaml: `
 run-name:
 - foo
 - bar
 `,
 		},
-		"yaml: invalid 'permissions' value, scalar": {
+		"invalid 'permissions' value, scalar": {
 			yaml: `
 permissions: 3.14
 `,
 		},
-		"yaml: invalid 'permissions' value, non-scalar": {
+		"invalid 'permissions' value, non-scalar": {
 			yaml: `
 permissions:
 - foo
 - bar
 `,
 		},
-		"yaml: invalid 'permissions.[*]' value": {
+		"invalid 'permissions.[*]' value": {
 			yaml: `
 permissions:
     issues: [3, 14]
 `,
 		},
-		"yaml: invalid 'concurrency' value": {
+		"invalid 'concurrency' value": {
 			yaml: `
 concurrency: [3, 14]
 `,
 		},
-		"yaml: invalid 'concurrency.cancel-in-progress' value": {
+		"invalid 'concurrency.cancel-in-progress' value": {
 			yaml: `
 concurrency:
     cancel-in-progress: ["foo", "bar"]
 `,
 		},
-		"yaml: invalid 'concurrency.group' value": {
+		"invalid 'concurrency.group' value": {
 			yaml: `
 concurrency:
     group: [42]
 `,
 		},
-		"yaml: invalid 'defaults' value": {
+		"invalid 'defaults' value": {
 			yaml: `
 defaults: 3
 `,
 		},
-		"yaml: invalid 'defaults.run' value": {
+		"invalid 'defaults.run' value": {
 			yaml: `
 defaults:
   run: 14
 `,
 		},
-		"yaml: invalid 'defaults.run.shell' value": {
+		"invalid 'defaults.run.shell' value": {
 			yaml: `
 defaults:
   run:
     shell: [3, 14]
 `,
 		},
-		"yaml: invalid 'defaults.run.working-directory' value": {
+		"invalid 'defaults.run.working-directory' value": {
 			yaml: `
 defaults:
   run:
     working-directory: [42]
 `,
 		},
-		"yaml: invalid 'env' value": {
+		"invalid 'env' value": {
 			yaml: `
 env: [3, 14]
 `,
 		},
-		"yaml: invalid 'jobs' value": {
+		"invalid 'jobs' value": {
 			yaml: `
 jobs: 3.14
 `,
 		},
-		"yaml: invalid job 'name' value": {
+		"invalid job 'name' value": {
 			yaml: `
 jobs:
   example:
@@ -996,7 +979,7 @@ jobs:
     - uses: actions/checkout@v4
 `,
 		},
-		"yaml: invalid job 'environment' value": {
+		"invalid job 'environment' value": {
 			yaml: `
 jobs:
   example:
@@ -1005,28 +988,28 @@ jobs:
     - bar
 `,
 		},
-		"yaml: invalid job 'continue-on-error' value": {
+		"invalid job 'continue-on-error' value": {
 			yaml: `
 jobs:
   example:
     continue-on-error: foobar
 `,
 		},
-		"yaml: invalid job 'timeout-minutes' value": {
+		"invalid job 'timeout-minutes' value": {
 			yaml: `
 jobs:
   example:
     timeout-minutes: foobar
 `,
 		},
-		"yaml: invalid job 'if' value": {
+		"invalid job 'if' value": {
 			yaml: `
 jobs:
   example:
     if: [3, 14]
 `,
 		},
-		"yaml: invalid job 'needs' value": {
+		"invalid job 'needs' value": {
 			yaml: `
 jobs:
   example:
@@ -1034,14 +1017,14 @@ jobs:
       foo: bar
 `,
 		},
-		"yaml: invalid job 'concurrency' value": {
+		"invalid job 'concurrency' value": {
 			yaml: `
 jobs:
   example:
     concurrency: [3, 14]
 `,
 		},
-		"yaml: invalid job 'concurrency.cancel-in-progress' value": {
+		"invalid job 'concurrency.cancel-in-progress' value": {
 			yaml: `
 jobs:
   example:
@@ -1049,7 +1032,7 @@ jobs:
       cancel-in-progress: ["foo", "bar"]
 `,
 		},
-		"yaml: invalid job 'concurrency.group' value": {
+		"invalid job 'concurrency.group' value": {
 			yaml: `
 jobs:
   example:
@@ -1057,14 +1040,14 @@ jobs:
       group: [42]
 `,
 		},
-		"yaml: invalid job 'defaults' value": {
+		"invalid job 'defaults' value": {
 			yaml: `
 jobs:
   example:
     defaults: foobar
 `,
 		},
-		"yaml: invalid job 'defaults.run' value": {
+		"invalid job 'defaults.run' value": {
 			yaml: `
 jobs:
   example:
@@ -1072,7 +1055,7 @@ jobs:
       run: 14
 `,
 		},
-		"yaml: invalid job 'defaults.run.shell' value": {
+		"invalid job 'defaults.run.shell' value": {
 			yaml: `
 jobs:
   example:
@@ -1081,7 +1064,7 @@ jobs:
          shell: [3, 14]
 `,
 		},
-		"yaml: invalid job 'defaults.run.working-directory' value": {
+		"invalid job 'defaults.run.working-directory' value": {
 			yaml: `
 jobs:
   example:
@@ -1090,7 +1073,7 @@ jobs:
         working-directory: [42]
 `,
 		},
-		"yaml: invalid job 'strategy.matrix' value": {
+		"invalid job 'strategy.matrix' value": {
 			yaml: `
 jobs:
   example:
@@ -1098,7 +1081,7 @@ jobs:
       matrix: 42
 `,
 		},
-		"yaml: invalid job 'strategy.matrix.include' value": {
+		"invalid job 'strategy.matrix.include' value": {
 			yaml: `
 jobs:
   example:
@@ -1107,7 +1090,7 @@ jobs:
         include: 42
 `,
 		},
-		"yaml: invalid job 'strategy.matrix.include[*]' value": {
+		"invalid job 'strategy.matrix.include[*]' value": {
 			yaml: `
 jobs:
   example:
@@ -1117,7 +1100,7 @@ jobs:
           - 42
 `,
 		},
-		"yaml: invalid job 'strategy.matrix.exclude' value": {
+		"invalid job 'strategy.matrix.exclude' value": {
 			yaml: `
 jobs:
   example:
@@ -1126,7 +1109,7 @@ jobs:
         exclude: 42
 `,
 		},
-		"yaml: invalid job 'strategy.matrix.exclude[*]' value": {
+		"invalid job 'strategy.matrix.exclude[*]' value": {
 			yaml: `
 jobs:
   example:
@@ -1136,7 +1119,7 @@ jobs:
           - 42
 `,
 		},
-		"yaml: invalid job 'strategy.fail-fast' value": {
+		"invalid job 'strategy.fail-fast' value": {
 			yaml: `
 jobs:
   example:
@@ -1144,7 +1127,7 @@ jobs:
       fail-fast: [42]
 `,
 		},
-		"yaml: invalid job 'strategy.max-parallel' value": {
+		"invalid job 'strategy.max-parallel' value": {
 			yaml: `
 jobs:
   example:
@@ -1152,14 +1135,14 @@ jobs:
       max-parallel: [42]
 `,
 		},
-		"yaml: invalid job 'services' value": {
+		"invalid job 'services' value": {
 			yaml: `
 jobs:
   example:
     services: 42
 `,
 		},
-		"yaml: invalid job 'services.[*]' value": {
+		"invalid job 'services.[*]' value": {
 			yaml: `
 jobs:
   example:
@@ -1167,7 +1150,7 @@ jobs:
       example: 3.14
 `,
 		},
-		"yaml: invalid job 'services.[*].image' value": {
+		"invalid job 'services.[*].image' value": {
 			yaml: `
 jobs:
   example:
@@ -1176,7 +1159,7 @@ jobs:
         image: [3, 14]
 `,
 		},
-		"yaml: invalid job 'services.[*].credentials' value": {
+		"invalid job 'services.[*].credentials' value": {
 			yaml: `
 jobs:
   example:
@@ -1185,7 +1168,7 @@ jobs:
         credentials: foobar
 `,
 		},
-		"yaml: invalid job 'services.[*].credentials.username' value": {
+		"invalid job 'services.[*].credentials.username' value": {
 			yaml: `
 jobs:
   example:
@@ -1195,7 +1178,7 @@ jobs:
           username: ["foo", "bar"]
 `,
 		},
-		"yaml: invalid job 'services.[*].credentials.password' value": {
+		"invalid job 'services.[*].credentials.password' value": {
 			yaml: `
 jobs:
   example:
@@ -1206,7 +1189,7 @@ jobs:
             foo: bar
 `,
 		},
-		"yaml: invalid job 'services.[*].env' value": {
+		"invalid job 'services.[*].env' value": {
 			yaml: `
 jobs:
   example:
@@ -1215,7 +1198,7 @@ jobs:
         env: foobar
 `,
 		},
-		"yaml: invalid job 'services.[*].ports' value": {
+		"invalid job 'services.[*].ports' value": {
 			yaml: `
 jobs:
   example:
@@ -1224,7 +1207,7 @@ jobs:
         ports: foobar
 `,
 		},
-		"yaml: invalid job 'services.[*].volumes' value": {
+		"invalid job 'services.[*].volumes' value": {
 			yaml: `
 jobs:
   example:
@@ -1233,7 +1216,7 @@ jobs:
         volumes: foobar
 `,
 		},
-		"yaml: invalid job 'services.[*].options' value": {
+		"invalid job 'services.[*].options' value": {
 			yaml: `
 jobs:
   example:
@@ -1242,35 +1225,35 @@ jobs:
         options: [3, 14]
 `,
 		},
-		"yaml: invalid job 'outputs' value": {
+		"invalid job 'outputs' value": {
 			yaml: `
 jobs:
   example:
     outputs: [3, 14]
 `,
 		},
-		"yaml: invalid job 'permissions' value": {
+		"invalid job 'permissions' value": {
 			yaml: `
 jobs:
   example:
     permissions: [3, 14]
 `,
 		},
-		"yaml: invalid job 'env' value": {
+		"invalid job 'env' value": {
 			yaml: `
 jobs:
   example:
     env: foobar
 `,
 		},
-		"yaml: invalid job 'steps' value": {
+		"invalid job 'steps' value": {
 			yaml: `
 jobs:
   example:
     steps: 42
 `,
 		},
-		"yaml: invalid job 'uses' value": {
+		"invalid job 'uses' value": {
 			yaml: `
 jobs:
   example:
@@ -1278,7 +1261,7 @@ jobs:
       - name: actions/checkout@v4
 `,
 		},
-		"yaml: invalid job 'with' value": {
+		"invalid job 'with' value": {
 			yaml: `
 jobs:
   example:
@@ -1289,37 +1272,10 @@ jobs:
 
 	for name, tt := range errCases {
 		t.Run(name, func(t *testing.T) {
-			var err error
-			switch {
-			case strings.HasPrefix(name, "model:"):
-				_, err = yaml.Marshal(tt.model)
-			case strings.HasPrefix(name, "yaml:"):
-				err = yaml.Unmarshal([]byte(tt.yaml), &tt.model)
-			default:
-				t.Fatalf("Incorrect test name %q", name)
-			}
-
-			if err == nil {
+			if err := yaml.Unmarshal([]byte(tt.yaml), &tt.model); err == nil {
 				t.Error("Want an error, got none")
 			}
 		})
-	}
-
-	roundtrip := func(w Workflow) bool {
-		b, err := yaml.Marshal(w)
-		if err != nil {
-			return true
-		}
-
-		if err := yaml.Unmarshal(b, &w); err != nil {
-			return false
-		}
-
-		return true
-	}
-
-	if err := quick.Check(roundtrip, nil); err != nil {
-		t.Error(err)
 	}
 }
 


### PR DESCRIPTION
It's too brittle and hard to make YAML marshalling work well. Much of the implementation was geared towards passing the test rather then trying to solve a real-world use case (perhaps with the exception of marshalling the `uses:` model).