### PR TITLE
Bump Go version to oldest supported version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/ericcornelissen/go-gha-models
 
-go 1.23.10
+go 1.24.13
 
 require go.yaml.in/yaml/v3 v3.0.4


### PR DESCRIPTION
Bump the version of Go used to 1.24, the latest supported version following the release of 1.26.0 recently. (see the [Go release policy](https://go.dev/doc/devel/release#policy))

related to #25